### PR TITLE
TOC Updated for Classic Era.

### DIFF
--- a/KiwiFarm.toc
+++ b/KiwiFarm.toc
@@ -1,6 +1,6 @@
 ## Interface: 110002
 ## Interface-Retail: 110002
-## Interface-Classic: 11503
+## Interface-Classic: 11504
 ## Interface-BCC: 20504
 ## Interface-Wrath: 30403
 ## Interface-Cata: 40400


### PR DESCRIPTION
中文翻译文件，这个地方没有加换行，导致显示错位